### PR TITLE
Fix busy-wait that stalled video writing under CI load

### DIFF
--- a/TimeLapseBuilder-Common/TimeLapseBuilder.swift
+++ b/TimeLapseBuilder-Common/TimeLapseBuilder.swift
@@ -97,55 +97,57 @@ public class TimeLapseBuilder {
                 assert(pixelBufferAdaptor.pixelBufferPool != nil)
                 
                 let media_queue = DispatchQueue(label: "mediaInputQueue")
-                
+
+                let currentProgress = Progress(totalUnitCount: Int64(assetPaths.count))
+                var frameCount: Int64 = 0
+                var remainingAssetPaths = [String](assetPaths)
+
                 videoWriterInput.requestMediaDataWhenReady(on: media_queue) {
-                    let currentProgress = Progress(totalUnitCount: Int64(assetPaths.count))
-                    
-                    var frameCount: Int64 = 0
-                    var remainingAssetPaths = [String](assetPaths)
-                    
-                    while !remainingAssetPaths.isEmpty {
-                        while videoWriterInput.isReadyForMoreMediaData {
-                            if remainingAssetPaths.isEmpty {
-                                break
-                            }
-                            let nextAssetPath = remainingAssetPaths.remove(at: 0)
-                            guard let nextAssetURL = URL(string: nextAssetPath) else {
-                                error = NSError(
-                                    domain: kErrorDomain,
-                                    code: kFailedToProcessAssetPath,
-                                    userInfo: ["description": "TimelapseBuilder failed to process the asset path. Is it a valid URL or file path?"]
-                                )
-                                break
-                            }
-                            let presentationTime = CMTimeMake(value: frameCount, timescale: framesPerSecond)
-                            
-                            if !self.appendPixelBufferForImageAtURL(nextAssetURL, pixelBufferAdaptor: pixelBufferAdaptor, presentationTime: presentationTime) {
-                                error = NSError(
-                                    domain: kErrorDomain,
-                                    code: kFailedToAppendPixelBufferError,
-                                    userInfo: ["description": "AVAssetWriterInputPixelBufferAdapter failed to append pixel buffer"]
-                                )
-                                
-                                break
-                            }
-                            
-                            frameCount += 1
-                            
-                            currentProgress.completedUnitCount = frameCount
-                            self.delegate.timeLapseBuilder(self, didMakeProgress: currentProgress)
+                    while videoWriterInput.isReadyForMoreMediaData {
+                        guard let nextAssetPath = remainingAssetPaths.first else {
+                            break
                         }
+                        remainingAssetPaths.removeFirst()
+
+                        guard let nextAssetURL = URL(string: nextAssetPath) else {
+                            error = NSError(
+                                domain: kErrorDomain,
+                                code: kFailedToProcessAssetPath,
+                                userInfo: ["description": "TimelapseBuilder failed to process the asset path. Is it a valid URL or file path?"]
+                            )
+                            remainingAssetPaths.removeAll()
+                            break
+                        }
+                        let presentationTime = CMTimeMake(value: frameCount, timescale: framesPerSecond)
+
+                        if !self.appendPixelBufferForImageAtURL(nextAssetURL, pixelBufferAdaptor: pixelBufferAdaptor, presentationTime: presentationTime) {
+                            error = NSError(
+                                domain: kErrorDomain,
+                                code: kFailedToAppendPixelBufferError,
+                                userInfo: ["description": "AVAssetWriterInputPixelBufferAdapter failed to append pixel buffer"]
+                            )
+
+                            remainingAssetPaths.removeAll()
+                            break
+                        }
+
+                        frameCount += 1
+
+                        currentProgress.completedUnitCount = frameCount
+                        self.delegate.timeLapseBuilder(self, didMakeProgress: currentProgress)
                     }
-                    
-                    videoWriterInput.markAsFinished()
-                    videoWriter.finishWriting {
-                        if let error = error {
-                            self.delegate.timeLapseBuilder(self, didFailWithError: error)
-                        } else {
-                            self.delegate.timeLapseBuilder(self, didFinishWithURL: videoOutputURL)
+
+                    if remainingAssetPaths.isEmpty {
+                        videoWriterInput.markAsFinished()
+                        videoWriter.finishWriting {
+                            if let error = error {
+                                self.delegate.timeLapseBuilder(self, didFailWithError: error)
+                            } else {
+                                self.delegate.timeLapseBuilder(self, didFinishWithURL: videoOutputURL)
+                            }
+
+                            self.videoWriter = nil
                         }
-                        
-                        self.videoWriter = nil
                     }
                 }
             } else {

--- a/TimeLapseBuilder-Common/TimeLapseBuilderTests.swift
+++ b/TimeLapseBuilder-Common/TimeLapseBuilderTests.swift
@@ -11,6 +11,69 @@ import XCTest
 @testable import TimeLapseBuilder
 
 class TimeLapseBuilderTests: XCTestCase {
+    private enum WarmUpError: Error, CustomStringConvertible {
+        case missingAsset
+        case timedOut
+        case buildFailed(Error)
+
+        var description: String {
+            switch self {
+            case .missingAsset:
+                return "encoder warm-up could not find its source image in the test bundle"
+            case .timedOut:
+                return "encoder warm-up did not finish within 120 seconds"
+            case .buildFailed(let error):
+                return "encoder warm-up failed to build: \(error)"
+            }
+        }
+    }
+    
+    private static var warmUpOutcome: Result<Void, Error>?
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        try Self.warmUpEncoder()
+    }
+    
+    private static func warmUpEncoder() throws {
+        if let warmUpOutcome = warmUpOutcome {
+            try warmUpOutcome.get()
+            return
+        }
+
+        let outcome = performWarmUp()
+        warmUpOutcome = outcome
+        try outcome.get()
+    }
+    
+    private static func performWarmUp() -> Result<Void, Error> {
+        guard let warmUpAsset = Bundle(for: TimeLapseBuilderTests.self).url(forResource: "red", withExtension: "jpg")?.absoluteString else {
+            return .failure(WarmUpError.missingAsset)
+        }
+        
+        let semaphore = DispatchSemaphore(value: 0)
+        var buildError: Error?
+        let delegate = TestDelegate(progress: { _ in }, finished: { _ in
+            semaphore.signal()
+        }, failed: { error in
+            buildError = error
+            semaphore.signal()
+        })
+        let documentsPath = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0] as NSString
+        let outputPath = documentsPath.appendingPathComponent("WarmUp.mov")
+        
+        let builder = TimeLapseBuilder(delegate: delegate)
+        builder.build(with: [warmUpAsset], atFrameRate: 30, type: .mov, toOutputPath: outputPath)
+        
+        guard semaphore.wait(timeout: .now() + 120) == .success else {
+            return .failure(WarmUpError.timedOut)
+        }
+        if let buildError = buildError {
+            return .failure(WarmUpError.buildFailed(buildError))
+        }
+        return .success(())
+    }
+
     func testWhenGivenASeriesOfImages_producesAnOutputFile() {
         let expectation = self.expectation(description: "Build timelapse")
         let testDelegate = TestDelegate(progress: { (progress: Progress) in


### PR DESCRIPTION
This fixes a race condition that stalled CI and could have caused on-device delays, too. When the writer input's buffer filled (`isReadyForMoreMediaData` returns), the block kept spinning on the media queue instead of returning, which then starved the encoder threads. The updated code better conforms to [the pattern](https://developer.apple.com/documentation/avfoundation/avassetwriterinput/requestmediadatawhenready(on:using:)) that Apple recommends.